### PR TITLE
chore(deps): use fbsim-ui v1.0.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "fbsim-web",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fbsim-web",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "GPL-3.0",
       "dependencies": {
-        "@whatsacomputertho/fbsim-ui": "file:../fbsim-ui",
+        "@whatsacomputertho/fbsim-ui": "^1.0.0-beta.2",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
@@ -27,28 +27,6 @@
         "tsx": "^4.0.0",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.0.0",
-        "vitest": "^3.0.0"
-      }
-    },
-    "../fbsim-ui": {
-      "version": "1.0.0-beta.1",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "@whatsacomputertho/fbsim-core": "^1.0.0-beta.1"
-      },
-      "devDependencies": {
-        "@eslint/js": "^9.0.0",
-        "@types/jest": "^30.0.0",
-        "@vitest/coverage-v8": "^3.0.0",
-        "@whatsacomputertho/fbsim-core": "file:../fbsim-core",
-        "eslint": "^9.0.0",
-        "eslint-config-prettier": "^10.0.0",
-        "happy-dom": "^20.5.0",
-        "prettier": "^3.4.0",
-        "typescript": "^5.7.0",
-        "typescript-eslint": "^8.0.0",
-        "vite": "^6.0.0",
-        "vite-plugin-dts": "^4.3.0",
         "vitest": "^3.0.0"
       }
     },
@@ -1091,9 +1069,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.19.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.10.tgz",
-      "integrity": "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw==",
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1503,9 +1481,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@whatsacomputertho/fbsim-core": {
+      "version": "1.0.0-beta.2-hotfix.1",
+      "resolved": "https://registry.npmjs.org/@whatsacomputertho/fbsim-core/-/fbsim-core-1.0.0-beta.2-hotfix.1.tgz",
+      "integrity": "sha512-HL2r9jFKB2IDtHFx90Dppi18ksxF55J35F7MOHHlZFNgBymhMOGyJ2ejUxB56mKuBKP2fdj+AHPY/k85DkNELA=="
+    },
     "node_modules/@whatsacomputertho/fbsim-ui": {
-      "resolved": "../fbsim-ui",
-      "link": true
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@whatsacomputertho/fbsim-ui/-/fbsim-ui-1.0.0-beta.2.tgz",
+      "integrity": "sha512-dSE42VqRH698LYWN/qNnqLdCJtyn3JtmT5hbiLLgry5pT/3rJnuqYj81Q1JQUwLBSzvt8MP4uOe5OvTfz07y0g==",
+      "dependencies": {
+        "@whatsacomputertho/fbsim-core": "^1.0.0-beta.1"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -3221,9 +3208,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dependencies": {
         "side-channel": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fbsim-web",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "type": "module",
   "description": "A web-based american football simulation user interface built atop the fbsim-core Rust crate",
   "main": "dist/index.js",
@@ -16,7 +16,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@whatsacomputertho/fbsim-ui": "file:../fbsim-ui",
+    "@whatsacomputertho/fbsim-ui": "^1.0.0-beta.2",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",


### PR DESCRIPTION
In this PR, I update the `package.json` to use `fbsim-ui` version `1.0.0-beta.2`.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/89
